### PR TITLE
mailisearch is now also available for arm64

### DIFF
--- a/stubs/meilisearch.stub
+++ b/stubs/meilisearch.stub
@@ -1,6 +1,5 @@
     meilisearch:
         image: 'getmeili/meilisearch:latest'
-        platform: linux/x86_64
         ports:
             - '${FORWARD_MEILISEARCH_PORT:-7700}:7700'
         volumes:


### PR DESCRIPTION
Hi. It works fine. `platform` can be removed.